### PR TITLE
Update swerve current limits

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -88,7 +88,7 @@ public final class Constants {
   }
 
   // ========================= Configuration Objects ========================
-  public static CurrentLimitsConfigs GetDefaultCurrentLimitsConfig() {
+  public static CurrentLimitsConfigs getDefaultCurrentLimitsConfig() {
     // Allow 40A continuous, 80A momentary supply current.
     // https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/configs/CurrentLimitsConfigs.html
     var limits = new CurrentLimitsConfigs();

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -1,5 +1,6 @@
 package frc.robot;
 
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -82,6 +83,18 @@ public final class Constants {
     REAL_WORLD,
     SIMULATION,
     LOG_REPLAY
+  }
+
+  // ========================= Configuration Objects ========================
+  public static CurrentLimitsConfigs GetDefaultCurrentLimitsConfig() {
+    // Allow 40A continuous, 80A momentary supply current.
+    // https://api.ctr-electronics.com/phoenix6/release/java/com/ctre/phoenix6/configs/CurrentLimitsConfigs.html
+    var limits = new CurrentLimitsConfigs();
+    limits.SupplyCurrentLimitEnable = true;
+    limits.SupplyCurrentLimit = 40.0;
+    limits.SupplyCurrentThreshold = 80.0;
+    limits.SupplyTimeThreshold = 0.5;
+    return limits;
   }
 
   // ========================= Constructors ===================================

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -7,11 +7,15 @@ import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 
 /**
- * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
- * constants. This class should not be used for any other purpose. All constants should be declared
+ * The Constants class provides a convenient place for teams to hold robot-wide
+ * numerical or boolean
+ * constants. This class should not be used for any other purpose. All constants
+ * should be declared
  * globally (i.e. public static). Do not put anything functional in this class.
  *
- * <p>It is advised to statically import this class (or one of its inner classes) wherever the
+ * <p>
+ * It is advised to statically import this class (or one of its inner classes)
+ * wherever the
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
@@ -36,15 +40,17 @@ public final class Constants {
   public static final double TRACK_WIDTH_X = Units.inchesToMeters(24.0);
   // Middle of left wheel to middle of right wheel.
   public static final double TRACK_WIDTH_Y = Units.inchesToMeters(24.0);
-  
+
   // ---------- Wheel & GHear Measurements ----------
   public static final double WHEEL_RADIUS = Units.inchesToMeters(2);
-  //public static final double WHEEL_DRIVE_GEAR_RATIO = (50.0 / 14.0) * (17.0 / 27.0) * (45.0 / 15.0);  //L2 Gear ratio
-  public static final double WHEEL_DRIVE_GEAR_RATIO = 6.12;  //L3 Gear ratio
+  // public static final double WHEEL_DRIVE_GEAR_RATIO = (50.0 / 14.0) * (17.0 /
+  // 27.0) * (45.0 / 15.0); //L2 Gear ratio
+  public static final double WHEEL_DRIVE_GEAR_RATIO = 6.12; // L3 Gear ratio
   public static final double WHEEL_TURN_GEAR_RATIO = 12.8;
 
-  // ---------- Wheel Rotation Offsets ---------- 
-  // Note: Chaning the Offset by Pie (180 degrees) will invert the direction the wheel spins.
+  // ---------- Wheel Rotation Offsets ----------
+  // Note: Chaning the Offset by Pie (180 degrees) will invert the direction the
+  // wheel spins.
   public static final Rotation2d FRONT_LEFT_ABSOLUTE_ENCODER_OFFSET = new Rotation2d(-2.26);
   public static final Rotation2d FRONT_RIGHT_ABSOLUTE_ENCODER_OFFSET = new Rotation2d(-0.35);
   public static final Rotation2d BACK_LEFT_ABSOLUTE_ENCODER_OFFSET = new Rotation2d(3.114);
@@ -79,6 +85,7 @@ public final class Constants {
   }
 
   // ========================= Constructors ===================================
-  /** Makes this class non-instantiable.*/
-  private Constants() {}
+  /** Makes this class non-instantiable. */
+  private Constants() {
+  }
 }

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
@@ -87,8 +87,11 @@ public class SwerveModuleIoTalonFx implements SwerveModuleIo {
 
     // Set Drive TalonFXConfiguration.
     var driveTalonFXConfiguration = new TalonFXConfiguration();
-    driveTalonFXConfiguration.CurrentLimits.StatorCurrentLimit = 40.0;
-    driveTalonFXConfiguration.CurrentLimits.StatorCurrentLimitEnable = true;
+    var currentLimits = driveTalonFXConfiguration.CurrentLimits;
+    currentLimits.StatorCurrentLimit = 40.0;
+    currentLimits.StatorCurrentLimitEnable = true;
+    currentLimits.SupplyCurrentThreshold = 80.0;
+    currentLimits.SupplyTimeThreshold = 0.5;
     driveMotor.getConfigurator().apply(driveTalonFXConfiguration);
 
     // Set Drive TalonFXConfiguration.

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
@@ -87,7 +87,7 @@ public class SwerveModuleIoTalonFx implements SwerveModuleIo {
 
     // Set Drive TalonFXConfiguration.
     var driveTalonFXConfiguration = new TalonFXConfiguration();
-    driveTalonFXConfiguration.CurrentLimits = Constants.GetDefaultCurrentLimitsConfig();
+    driveTalonFXConfiguration.CurrentLimits = Constants.getDefaultCurrentLimitsConfig();
     driveMotor.getConfigurator().apply(driveTalonFXConfiguration);
 
     // Set Drive TalonFXConfiguration.

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
@@ -87,11 +87,7 @@ public class SwerveModuleIoTalonFx implements SwerveModuleIo {
 
     // Set Drive TalonFXConfiguration.
     var driveTalonFXConfiguration = new TalonFXConfiguration();
-    var currentLimits = driveTalonFXConfiguration.CurrentLimits;
-    currentLimits.StatorCurrentLimit = 40.0;
-    currentLimits.StatorCurrentLimitEnable = true;
-    currentLimits.SupplyCurrentThreshold = 80.0;
-    currentLimits.SupplyTimeThreshold = 0.5;
+    driveTalonFXConfiguration.CurrentLimits = Constants.GetDefaultCurrentLimitsConfig();
     driveMotor.getConfigurator().apply(driveTalonFXConfiguration);
 
     // Set Drive TalonFXConfiguration.

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
@@ -54,7 +54,7 @@ public class SwerveModuleIoTalonFx implements SwerveModuleIo {
   private final Rotation2d absoluteEncoderOffset;
 
   public SwerveModuleIoTalonFx(WheelModuleIndex index) {
-    
+
     // Assign Motor and Encoder Ids and configue wheel offset.
     switch (index) {
       case FRONT_LEFT:
@@ -64,21 +64,21 @@ public class SwerveModuleIoTalonFx implements SwerveModuleIo {
         absoluteEncoderOffset = Constants.FRONT_LEFT_ABSOLUTE_ENCODER_OFFSET;
         break;
       case FRONT_RIGHT:
-      driveMotor = new TalonFX(Constants.FRONT_RIGHT_DRIVE_MOTOR_ID, Constants.CANIVORE_BUS_ID);
-      steerMotor = new TalonFX(Constants.FRONT_RIGHT_STEER_MOTOR_ID, Constants.CANIVORE_BUS_ID);
-      cancoder = new CANcoder(Constants.FRONT_RIGHT_CANCODER_ID, Constants.CANIVORE_BUS_ID);
+        driveMotor = new TalonFX(Constants.FRONT_RIGHT_DRIVE_MOTOR_ID, Constants.CANIVORE_BUS_ID);
+        steerMotor = new TalonFX(Constants.FRONT_RIGHT_STEER_MOTOR_ID, Constants.CANIVORE_BUS_ID);
+        cancoder = new CANcoder(Constants.FRONT_RIGHT_CANCODER_ID, Constants.CANIVORE_BUS_ID);
         absoluteEncoderOffset = Constants.FRONT_RIGHT_ABSOLUTE_ENCODER_OFFSET;
         break;
       case BACK_LEFT:
-      driveMotor = new TalonFX(Constants.BACK_LEFT_DRIVE_MOTOR_ID, Constants.CANIVORE_BUS_ID);
-      steerMotor = new TalonFX(Constants.BACK_LEFT_STEER_MOTOR_ID, Constants.CANIVORE_BUS_ID);
-      cancoder = new CANcoder(Constants.BACK_LEFT_CANCODER_ID, Constants.CANIVORE_BUS_ID);
+        driveMotor = new TalonFX(Constants.BACK_LEFT_DRIVE_MOTOR_ID, Constants.CANIVORE_BUS_ID);
+        steerMotor = new TalonFX(Constants.BACK_LEFT_STEER_MOTOR_ID, Constants.CANIVORE_BUS_ID);
+        cancoder = new CANcoder(Constants.BACK_LEFT_CANCODER_ID, Constants.CANIVORE_BUS_ID);
         absoluteEncoderOffset = Constants.BACK_LEFT_ABSOLUTE_ENCODER_OFFSET;
         break;
       case BACK_RIGHT:
-      driveMotor = new TalonFX(Constants.BACK_RIGHT_DRIVE_MOTOR_ID, Constants.CANIVORE_BUS_ID);
-      steerMotor = new TalonFX(Constants.BACK_RIGHT_STEER_MOTOR_ID, Constants.CANIVORE_BUS_ID);
-      cancoder = new CANcoder(Constants.BACK_RIGHT_CANCODER_ID, Constants.CANIVORE_BUS_ID);
+        driveMotor = new TalonFX(Constants.BACK_RIGHT_DRIVE_MOTOR_ID, Constants.CANIVORE_BUS_ID);
+        steerMotor = new TalonFX(Constants.BACK_RIGHT_STEER_MOTOR_ID, Constants.CANIVORE_BUS_ID);
+        cancoder = new CANcoder(Constants.BACK_RIGHT_CANCODER_ID, Constants.CANIVORE_BUS_ID);
         absoluteEncoderOffset = Constants.BACK_RIGHT_ABSOLUTE_ENCODER_OFFSET;
         break;
       default:
@@ -90,11 +90,11 @@ public class SwerveModuleIoTalonFx implements SwerveModuleIo {
     driveTalonFXConfiguration.CurrentLimits.StatorCurrentLimit = 40.0;
     driveTalonFXConfiguration.CurrentLimits.StatorCurrentLimitEnable = true;
     driveMotor.getConfigurator().apply(driveTalonFXConfiguration);
-    
+
     // Set Drive TalonFXConfiguration.
     var driveMotorOutputConfigs = new MotorOutputConfigs();
     driveMotorOutputConfigs.NeutralMode = Constants.WHEEL_BRAKE_MODE;
-     // Inverted to match our Swerve Drive Module Gear Box & Motors.
+    // Inverted to match our Swerve Drive Module Gear Box & Motors.
     driveMotorOutputConfigs.Inverted = InvertedValue.Clockwise_Positive;
     driveMotor.getConfigurator().apply(driveMotorOutputConfigs);
 
@@ -103,11 +103,11 @@ public class SwerveModuleIoTalonFx implements SwerveModuleIo {
     steerTalonFXConfiguration.CurrentLimits.StatorCurrentLimit = 30.0;
     steerTalonFXConfiguration.CurrentLimits.StatorCurrentLimitEnable = true;
     steerMotor.getConfigurator().apply(steerTalonFXConfiguration);
-    
+
     // Set Steer MotorOutputConfigs.
     var steerMotorOutputConfigs = new MotorOutputConfigs();
     steerMotorOutputConfigs.NeutralMode = Constants.WHEEL_BRAKE_MODE;
-     // Inverted to match our Swerve Drive Module Gear Box & Motors.
+    // Inverted to match our Swerve Drive Module Gear Box & Motors.
     steerMotorOutputConfigs.Inverted = InvertedValue.CounterClockwise_Positive;
     steerMotor.getConfigurator().apply(steerMotorOutputConfigs);
 
@@ -166,15 +166,21 @@ public class SwerveModuleIoTalonFx implements SwerveModuleIo {
         steerMotorAppliedVolts,
         steerMotorStatorCurrent);
 
-    // Inverted driveMotorPosition so that sutonomous sees the robot moving in the correct direction.
-    inputs.driveMotorPositionRad = Units.rotationsToRadians(-driveMotorPosition.getValueAsDouble()) / Constants.WHEEL_DRIVE_GEAR_RATIO;
-    inputs.driveMotorVelocityRadPerSec = Units.rotationsToRadians(driveMotorVelocity.getValueAsDouble()) / Constants.WHEEL_DRIVE_GEAR_RATIO;
+    // Inverted driveMotorPosition so that sutonomous sees the robot moving in the
+    // correct direction.
+    inputs.driveMotorPositionRad = Units.rotationsToRadians(-driveMotorPosition.getValueAsDouble())
+        / Constants.WHEEL_DRIVE_GEAR_RATIO;
+    inputs.driveMotorVelocityRadPerSec = Units.rotationsToRadians(driveMotorVelocity.getValueAsDouble())
+        / Constants.WHEEL_DRIVE_GEAR_RATIO;
     inputs.driveMotorAppliedVolts = driveMotorAppliedVolts.getValueAsDouble();
     inputs.driveMotorCurrentAmps = driveMotorCurrent.getValueAsDouble();
 
-    inputs.cancoderAbsolutePosition = Rotation2d.fromRotations(cancoderAbsolutePosition.getValueAsDouble()).minus(absoluteEncoderOffset);
-    inputs.steerMotorPosition = Rotation2d.fromRotations(steerMotorPosition.getValueAsDouble() / Constants.WHEEL_TURN_GEAR_RATIO);
-    inputs.steerMotorVelocityRadPerSec = Units.rotationsToRadians(steerMotorVelocity.getValueAsDouble()) / Constants.WHEEL_TURN_GEAR_RATIO;
+    inputs.cancoderAbsolutePosition = Rotation2d.fromRotations(cancoderAbsolutePosition.getValueAsDouble())
+        .minus(absoluteEncoderOffset);
+    inputs.steerMotorPosition = Rotation2d
+        .fromRotations(steerMotorPosition.getValueAsDouble() / Constants.WHEEL_TURN_GEAR_RATIO);
+    inputs.steerMotorVelocityRadPerSec = Units.rotationsToRadians(steerMotorVelocity.getValueAsDouble())
+        / Constants.WHEEL_TURN_GEAR_RATIO;
     inputs.steerMotorAppliedVolts = steerMotorAppliedVolts.getValueAsDouble();
     inputs.steerMotorCurrentAmps = steerMotorStatorCurrent.getValueAsDouble();
   }


### PR DESCRIPTION
Allow momentary drive motor current to be higher.

(There are formatting changes; review the PR with whitespace turned off).
