### PR TITLE
Fix status signals

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -38,6 +38,8 @@ public final class Constants {
   // ---------- Driving Config ----------
   public static final double JOYSTICK_DEADBAND = 0.2;
   public static final double MAX_LINEAR_SPEED_IN_METERS_PER_SECOND = 3.0;
+  public static final double ADVANTAGE_ODOMETRY_LOG_FREQUENCY = 100.0;
+  public static final double ADVANTAGE_DEFAULT_LOG_FREQUENCY = 50.0;
 
   // ---------- Robot Measurements ----------
   // Middle of front wheel to middle of back wheel.

--- a/src/main/java/frc/robot/subsystems/shooter/Flywheel.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Flywheel.java
@@ -77,6 +77,14 @@ public class Flywheel extends SubsystemBase {
         flywheelRFaults = flywheelMotorR.getFaultField();
 
         // ---------- Optimize Bus Utilization ----------
+        BaseStatusSignal.setUpdateFrequencyForAll(
+                Constants.ADVANTAGE_DEFAULT_LOG_FREQUENCY,
+                flywheelLMotorVoltage, flywheelRMotorVoltage,
+                flywheelLSupplyCurrent, flywheelRSupplyCurrent,
+                flywheelLSupplyVoltage, flywheelRSupplyVoltage,
+                flywheelLVelocity, flywheelRVelocity,
+                flywheelLMotorTemp, flywheelRMotorTemp,
+                flywheelLFaults, flywheelRFaults);
         flywheelMotorL.optimizeBusUtilization();
         flywheelMotorR.optimizeBusUtilization();
     }

--- a/src/main/java/frc/robot/subsystems/swerve/IndexedSwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/swerve/IndexedSwerveModule.java
@@ -1,13 +1,13 @@
 package frc.robot.subsystems.swerve;
 
+import org.littletonrobotics.junction.Logger;
+
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import frc.robot.Constants;
-
-import org.littletonrobotics.junction.Logger;
 
 public class IndexedSwerveModule {
 

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModuleIoTalonFx.java
@@ -129,6 +129,20 @@ public class SwerveModuleIoTalonFx implements SwerveModuleIo {
     steerMotorFaults = steerMotor.getFaultField();
     steerMotorTemp = steerMotor.getDeviceTemp();
 
+    // Set Update frequency.
+    BaseStatusSignal.setUpdateFrequencyForAll(
+        Constants.ADVANTAGE_ODOMETRY_LOG_FREQUENCY, driveMotorPosition, steerMotorPosition); // Required for odometry,
+                                                                                             // use faster rate
+    BaseStatusSignal.setUpdateFrequencyForAll(
+        Constants.ADVANTAGE_DEFAULT_LOG_FREQUENCY,
+        driveMotorVelocity,
+        driveMotorAppliedVolts,
+        driveMotorCurrent,
+        cancoderAbsolutePosition,
+        steerMotorVelocity,
+        steerMotorAppliedVolts,
+        steerMotorStatorCurrent);
+
     driveMotor.optimizeBusUtilization();
     steerMotor.optimizeBusUtilization();
   }


### PR DESCRIPTION
Restoring the call to `BaseStatusSignal.setUpdateFrequencyForAll` resolves the issue with the turn motors.