### PR TITLE
Fix vision origin and zero readings

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -85,7 +85,7 @@ public final class Constants {
 
   // ---------- Hardware Ids ----------
   // --- Camera ---
-  public static final String CAMERA_1_NAME = "front"; // TODO: Set Value.
+  public static final String SHOOTER_CAMERA_NAME = "limelight-shooter";
   // --- Canivore ---
   public static final String CANIVORE_BUS_ID = "1559Canivore";
   // --- Flywheel ---

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -70,7 +70,7 @@ public class RobotContainer {
             new SwerveModuleIoTalonFx(WheelModuleIndex.FRONT_RIGHT),
             new SwerveModuleIoTalonFx(WheelModuleIndex.BACK_LEFT),
             new SwerveModuleIoTalonFx(WheelModuleIndex.BACK_RIGHT));
-        vision = new Vision(driveBase.getPoseEstimator(), new VisionIoLimelight(Constants.CAMERA_1_NAME));
+        vision = new Vision(driveBase.getPoseEstimator(), new VisionIoLimelight(Constants.SHOOTER_CAMERA_NAME));
         break;
 
       case SIMULATION:

--- a/src/main/java/frc/robot/subsystems/vision/VisionIoLimelight.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIoLimelight.java
@@ -19,9 +19,9 @@ public class VisionIoLimelight implements VisionIo {
     }
 
     public void updateInputs(VisionInputs inputs) {
-        double[] data = LimelightHelpers.getBotPose(cameraName);
+        double[] data = LimelightHelpers.getBotPose_wpiBlue(cameraName);
 
-        if (data.length < 6) {
+        if (data.length < 6 || (data[0] == 0 && data[1] == 0)) {
             inputs.havePose = false;
             inputs.pose = new Pose2d();
             inputs.timestamp = 0;


### PR DESCRIPTION
Vision readings were relative to the field center; we needed to call `getBotPose_wpiBlue` to get this in the coordinate space expected by PathPlanner. Also suppress readings at the origin as being "no pose".