### PR TITLE
Fix camera name

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -85,7 +85,7 @@ public final class Constants {
 
   // ---------- Hardware Ids ----------
   // --- Camera ---
-  public static final String SHOOTER_CAMERA_NAME = "limelight-shooter";
+  public static final String SHOOTER_CAMERA_NAME = "limelight";
   // --- Canivore ---
   public static final String CANIVORE_BUS_ID = "1559Canivore";
   // --- Flywheel ---


### PR DESCRIPTION
The limelight networking was reset, and this changes the name back to "limelight". Since we only have one camera, let's use that name so we are immune to resets.