### PR TITLE
Reduce vision stdevs so we trust vision more

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/VisionIoLimelight.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIoLimelight.java
@@ -7,7 +7,7 @@ import edu.wpi.first.wpilibj.Timer;
 import frc.robot.subsystems.vision.Vision.VisionInputs;
 
 public class VisionIoLimelight implements VisionIo {
-    private final double[] STD_DEVS = { 1.0, 1.0, 2.0 };
+    private final double[] STD_DEVS = { 0.5, 0.5, 0.5 };
     private String cameraName;
 
     public VisionIoLimelight(String cameraName) {


### PR DESCRIPTION
Vision stdevs are currently 1 meter in X and Y and 2 radians in R. This results in very slow convergence when first acquiring a pose on the field (especially on the red side), which is an issue for field relative driving if we did not see tags during auto.

Actual vision readings are much more consistent than that (typical variation is +/- a few cm), but this PR just reduces them initially to 0.5m in X and Y and 0.5 radians in R. We should experiment with the values a little. 