### PR TITLE
Uncheck starting pose for all autos

### DIFF
--- a/src/main/deploy/pathplanner/autos/Any - 1 (stay).auto
+++ b/src/main/deploy/pathplanner/autos/Any - 1 (stay).auto
@@ -1,12 +1,6 @@
 {
   "version": 1.0,
-  "startingPose": {
-    "position": {
-      "x": 1.4129651008117177,
-      "y": 5.524739769858686
-    },
-    "rotation": 0
-  },
+  "startingPose": null,
   "command": {
     "type": "sequential",
     "data": {

--- a/src/main/deploy/pathplanner/autos/Center - 1.auto
+++ b/src/main/deploy/pathplanner/autos/Center - 1.auto
@@ -1,12 +1,6 @@
 {
   "version": 1.0,
-  "startingPose": {
-    "position": {
-      "x": 0.8001858657745748,
-      "y": 3.8225752280888443
-    },
-    "rotation": -2.1468902751028387
-  },
+  "startingPose": null,
   "command": {
     "type": "sequential",
     "data": {

--- a/src/main/deploy/pathplanner/autos/FINALS.auto
+++ b/src/main/deploy/pathplanner/autos/FINALS.auto
@@ -1,12 +1,6 @@
 {
   "version": 1.0,
-  "startingPose": {
-    "position": {
-      "x": 2,
-      "y": 2
-    },
-    "rotation": 0
-  },
+  "startingPose": null,
   "command": {
     "type": "sequential",
     "data": {

--- a/src/main/deploy/pathplanner/autos/Far - 1.auto
+++ b/src/main/deploy/pathplanner/autos/Far - 1.auto
@@ -1,12 +1,6 @@
 {
   "version": 1.0,
-  "startingPose": {
-    "position": {
-      "x": 1.067429295352418,
-      "y": 2.9374496663685266
-    },
-    "rotation": -2.1468902751028387
-  },
+  "startingPose": null,
   "command": {
     "type": "sequential",
     "data": {

--- a/src/main/deploy/pathplanner/autos/TEST - DO NOT USE.auto
+++ b/src/main/deploy/pathplanner/autos/TEST - DO NOT USE.auto
@@ -1,12 +1,6 @@
 {
   "version": 1.0,
-  "startingPose": {
-    "position": {
-      "x": 2,
-      "y": 2
-    },
-    "rotation": 0
-  },
+  "startingPose": null,
   "command": {
     "type": "sequential",
     "data": {


### PR DESCRIPTION
Having a starting pose in the auto routine can cause errors. For example, in Pittsburgh elimination match 1, it did this:
* Prior to auto starting, vision determined that we were right of the speaker
* When auto started, the auto routine set the pose to be directly in front of the speaker
* Once enabled, vision corrected the reading back to the right side. But before the rotation could converge, the robot rotated "toward the target" resulting in a shot into the stands.

This PR turns off preset poses for the remaining auto routines that use them.